### PR TITLE
Encode URLs containing '/'

### DIFF
--- a/src/service/artifact.ts
+++ b/src/service/artifact.ts
@@ -60,7 +60,7 @@ export async function getArtifacts(
           pullTime: dateFormat(element.pull_time, "yyyy-mm-dd HH:MM"),
           pushTime: dateFormat(element.push_time, "yyyy-mm-dd HH:MM"),
           projectID: projectId,
-          repoUrl: `${baseUrl}/harbor/projects/${projectId}/repositories/${repository}`,
+          repoUrl: `${baseUrl}/harbor/projects/${projectId}/repositories/${repository.replace(/\//g, "%2F")}`,
           vulnerabilities: {
             count: Object.keys(vulns[vulnKey].vulnerabilities).length,
             severity: severity,


### PR DESCRIPTION
Make sure repositories containing '/' are encoded. This fixes the broken 'Learn More' link for multilevel repositories, i.e myteam/myimage