### PR TITLE
Let the code flow even if there is no vulnerability or severity

### DIFF
--- a/src/service/artifact.ts
+++ b/src/service/artifact.ts
@@ -44,6 +44,9 @@ export async function getArtifacts(
 
         const vulnKey =
           'application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0'
+        if (vulns[vulnKey] === undefined) {
+          vulns[vulnKey] = {severity: 'Unknown', vulnerabilities:[] }
+        }
         let severity = vulns[vulnKey].severity
         if (severity === 'Unknown') {
           severity = 'None'


### PR DESCRIPTION
Let the code flow even if there is no vulnerability or severity (happens when not all images are scanned in harbor)